### PR TITLE
Object handle providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,48 @@
   
 All notable changes to this project will be documented in this file.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/), from version **1.3.0** on.  
-  
+
+## [1.8.2] - 2023-09-03
+
+### Added
+
+- Get-ObjectHandle.
+  Proudly announce that `Get-ObjectHandle` now returns handles opened for registry keys, with full
+  provider awareness.
+
+### Changed
+
+- Get-ObjectHandle.
+  Improved the provider awareness both to support registry keys, and handle unsupported PS providers.
+
+## [1.8.1] - 2023-09-01
+
+### Added
+
+- Start-Tcping.
+  Added alias 'tcping'.
+
+## [1.8.0] - 2023-09-01
+
+### Added
+
+- Start-Tcping.
+  - New cmdlet that 'pings' a destination server(s) in the specified port(s).
+- WuStdException.
+  - Implementing `Start-Tcping` brought a lot of challenges, the most noticeable one was the performance while
+    returning from functions. `WuStdException` is a C++ `std::exception` based class to slowly shift from 
+    return codes to proper error handling.
+
+### Changed
+
+- NATIVE_CONTEXT -> WuNativeContext.
+  - `WuNativeContext` is an improved version of the old `NATIVE_CONTEXT`, again to make the whole process more
+  efficient and reliable.
+- Shared Memory.
+  - The shared memory scheme changed from using memory mapped IO to using `System.IO.UnmanagedMemoryStream`,
+    which is basically a memory space to be used between Managed/Unmanaged code.
+ 
+
 ## [1.7.0] - 2023-08-21
 
 The version 1.7.0 marks a turning point into this project. A lot of important things were added, and changed.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To get information on how to use it, use **Get-Help _Cmdlet-Name_ -Full**.
     - [Get-InstalledDotnet](#get-installeddotnet)
     - [Expand-Cabinet](#expand-cabinet)
     - [Start-Tcping](#start-tcping)
+    - [Start-ProcessAsUser](#start-processasuser)
   - [Changelog](#changelog)
   - [Support](#support)
   
@@ -301,38 +302,48 @@ The parameters contain aliases that mimic the parameter in those applications.
 ```powershell-console
 Start-Tcping -Destination learn.microsoft.com  -Port 443 -IncludeJitter
 
-Probing learn.microsoft.com [2600:1419:6200:284::3544] on port 443:
-2600:1419:6200:284::3544 - TCP:443 - Port is open - time=10.84ms
-2600:1419:6200:284::3544 - TCP:443 - Port is open - time=9.54ms jitter=1.31ms
-2600:1419:6200:284::3544 - TCP:443 - Port is open - time=11.33ms jitter=1.14ms
-2600:1419:6200:284::3544 - TCP:443 - Port is open - time=11.07ms jitter=0.51ms
+Destination                    Port  Status  Times
+-----------                    ----  ------  -----
+learn.microsoft.com            443   Open    Rtt: 7.14
+learn.microsoft.com            443   Open    Rtt: 8.50, Jitter: 1.36
+learn.microsoft.com            443   Open    Rtt: 9.50, Jitter: 1.68
+learn.microsoft.com            443   Open    Rtt: 7.59, Jitter: 0.79
 
-Pinging statistics for 2600:1419:6200:284::3544:
-        Packets: Sent = 4, Successful = 4, Failed = 0 (0%),
-Approximate round trip times in milli-seconds:
-        Minimum = 9.54ms, Maximum = 11.33ms, Average = 10.70ms,
-Approximate jitter in milli-seconds:
-        Minimum = 0.51ms, Maximum = 1.31ms, Average = 0.98m
+Sent          : 4
+Succeeded     : 4
+Failed        : 0
+FailedPercent : 0.00%
+MinTimes      : Rtt: 7.59, Jitter: 0.79
+AvgTimes      : Rtt: 8.18, Jitter: 1.28
+MaxTimes      : Rtt: 9.50, Jitter: 1.68
 ```
 
 ```powershell-console
-Start-Tcping learn.microsoft.com -j -d -t
+tcping learn.microsoft.com, google.com -Port 80, 443 -s
 
-Probing learn.microsoft.com [2600:1419:6200:289::3544] continuously on port 80 (press Ctrl + C to stop):
-2023-8-29 23:44:52.751 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=6.43ms
-2023-8-29 23:44:53.772 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=12.59ms jitter=6.16ms
-2023-8-29 23:44:54.794 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=12.74ms jitter=3.23ms
-2023-8-29 23:44:55.817 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=8.51ms jitter=2.07ms
-2023-8-29 23:44:56.842 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=12.45ms jitter=2.38ms
-2023-8-29 23:44:57.866 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=11.35ms jitter=0.80ms
-2023-8-29 23:44:58.889 - 2600:1419:6200:289::3544 - TCP:80 - Port is open - time=8.79ms jitter=1.89ms
+Destination                    Port  Status  Times
+-----------                    ----  ------  -----
+learn.microsoft.com            80    Open    Rtt: 8.32
+learn.microsoft.com            443   Open    Rtt: 19.91
+google.com                     80    Open    Rtt: 9.57
+google.com                     443   Open    Rtt: 7.01
+```
 
-Pinging statistics for 2600:1419:6200:289::3544:
-        Packets: Sent = 7, Successful = 7, Failed = 0 (0%),
-Approximate round trip times in milli-seconds:
-        Minimum = 8.51ms, Maximum = 12.74ms, Average = 10.41ms,
-Approximate jitter in milli-seconds:
-        Minimum = 0.80ms, Maximum = 6.16ms, Average = 2.76ms
+### Start-ProcessAsUser
+
+This Cmdlet logs in a user and starts a process with it.
+This is my terrible attempt to reverse engineer 'runas.exe'.
+It works by typing the credentials in the go, like 'runas.exe', or using
+a `PSCredential`.
+
+```powershell
+Start-ProcessAsUser CONTOSO\francisco.nabas powershell
+```
+
+Of course we have an alias for it.
+
+```powershell
+runas -CommandLine powershell -Credential (Get-Credential)
 ```
 
 ## Changelog

--- a/Tools/PSModule/WindowsUtils.Format.ps1xml
+++ b/Tools/PSModule/WindowsUtils.Format.ps1xml
@@ -34,6 +34,51 @@
             </TableControl>
         </View>
         <View>
+            <Name>WindowsUtils.ObjectHandle</Name>
+            <ViewSelectedBy>
+                <TypeName>WindowsUtils.ObjectHandle</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Width>11</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>13</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>45</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>10</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Type</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>InputObject</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>ProcessId</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Description</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
             <Name>WindowsUtils.TcpingProbeInfo</Name>
             <ViewSelectedBy>
                 <TypeName>WindowsUtils.TcpingProbeInfo</TypeName>

--- a/Tools/PSModule/WindowsUtils.Types.ps1xml
+++ b/Tools/PSModule/WindowsUtils.Types.ps1xml
@@ -65,7 +65,7 @@
       </MemberSet>
     </Members>
   </Type>
-  <Type>
+  <!-- <Type>
     <Name>WindowsUtils.ObjectHandle</Name>
     <Members>
       <MemberSet>
@@ -83,7 +83,7 @@
         </Members>
       </MemberSet>
     </Members>
-  </Type>
+  </Type> -->
   <Type>
     <Name>WindowsUtils.AccessControl.ServiceSecurity</Name>
     <Members>

--- a/Tools/PSModule/WindowsUtils.psd1
+++ b/Tools/PSModule/WindowsUtils.psd1
@@ -1,6 +1,6 @@
 @{
     GUID = 'C5F7B91E-668D-46AC-9F0E-23B0A74ABCBA'
-    ModuleVersion = '1.8.1'
+    ModuleVersion = '1.8.2'
     RootModule = 'WindowsUtils.dll'
     CompatiblePSEditions = @(
         'Desktop',

--- a/src/ClrCore/Headers/Common.h
+++ b/src/ClrCore/Headers/Common.h
@@ -62,7 +62,7 @@ private:
 	int m_windowsError;
 	WWuString m_message;
 	WWuString m_compactTrace;
-	
+
 	void SetMessage(bool isNt)
 	{
 		LPWSTR buffer = NULL;
@@ -100,7 +100,7 @@ private:
 	{
 		switch (m_windowsError) {
 			case FDIERROR_CABINET_NOT_FOUND:
-				 m_message = L"Cabinet not found";
+				m_message = L"Cabinet not found";
 
 			case FDIERROR_NOT_A_CABINET:
 				m_message = L"File is not a cabinet";
@@ -138,29 +138,34 @@ private:
 	}
 };
 
-class WuResult {
+class WuResult
+{
 public:
 	long Result;
 	WWuString Message;
 	WWuString CompactTrace;
 
 	WuResult()
-		: Result(ERROR_SUCCESS) { }
+		: Result(ERROR_SUCCESS)
+	{ }
 
 	WuResult(long errorCode, LPWSTR fileName, DWORD lineNumber, bool isNt = false)
-		: Result(errorCode) {
+		: Result(errorCode)
+	{
 		Message = GetErrorMessage(errorCode, isNt);
 		CompactTrace = GetCompactTrace(fileName, lineNumber);
 	}
 
 	WuResult(long errorCode, const WWuString& message, LPWSTR fileName, DWORD lineNumber)
-		: Result(errorCode), Message(message) {
+		: Result(errorCode), Message(message)
+	{
 		CompactTrace = GetCompactTrace(fileName, lineNumber);
 	}
 
 	~WuResult() { }
 
-	_NODISCARD static WWuString GetErrorMessage(long errorCode, bool isNt) {
+	_NODISCARD static WWuString GetErrorMessage(long errorCode, bool isNt)
+	{
 		if (isNt) {
 			HMODULE hModule = GetModuleHandle(L"ntdll.dll");
 			if (hModule == NULL)
@@ -189,7 +194,8 @@ public:
 		}
 	}
 
-	_NODISCARD static WWuString GetCompactTrace(LPWSTR fileName, DWORD lineNumber) {
+	_NODISCARD static WWuString GetCompactTrace(LPWSTR fileName, DWORD lineNumber)
+	{
 		WWuString wrappedName(fileName);
 		auto fileNameSplit = wrappedName.Split('\\');
 		WWuString relPath;
@@ -208,7 +214,8 @@ public:
 		return WWuString::Format(L"%ws:%d", relPath.GetBuffer(), lineNumber);
 	}
 
-	static WuResult GetResultFromFdiError(const FDIERROR& err, LPWSTR fileName, DWORD lineNumber) {
+	static WuResult GetResultFromFdiError(const FDIERROR& err, LPWSTR fileName, DWORD lineNumber)
+	{
 		switch (err) {
 			case FDIERROR_CABINET_NOT_FOUND:
 				return WuResult(FDIERROR_CABINET_NOT_FOUND, L"Cabinet not found", fileName, lineNumber);

--- a/src/ClrCore/Headers/NtUtilities.h
+++ b/src/ClrCore/Headers/NtUtilities.h
@@ -3,6 +3,7 @@
 
 #include "Common.h"
 #include "String.h"
+#include "Expressions.h"
 
 #define STATUS_SUCCESS ERROR_SUCCESS
 #define STATUS_BUFFER_TOO_SMALL 0xC0000023L
@@ -84,7 +85,7 @@ namespace WindowsUtils::Core
 	typedef struct _THREAD_FUNC_ARGUMENTS {
 		HANDLE						ObjectHandle;
 		OBJECT_INFORMATION_CLASS	ObjectInformationClass;
-		PVOID						ObjectInfo;
+		wuunique_ptr<BYTE[]>&		ObjectInfo;
 	}THREAD_FUNC_ARGUMENTS, * PTHREAD_FUNC_ARGUMENTS;
 
 	typedef struct _PROCESS_HANDLE_TABLE_ENTRY_INFO
@@ -208,8 +209,10 @@ namespace WindowsUtils::Core
 	==		 Function identification		==
 	==========================================*/
 
-	WuResult GetNtProcessUsingFile(const WWuString& fileName, wuunique_ha_ptr<FILE_PROCESS_IDS_USING_FILE_INFORMATION>& procUsingFileInfo);
+	void GetProcessUsingFile(const WWuString& fileName, wuvector<DWORD>& processIdList);
+	void GetProcessUsingObject(const WWuString& objectName, wuvector<DWORD>& processIdList, bool closeHandle);
+	void GetRunnningProcessIdList(wuvector<DWORD>& procIdList);
 	DWORD WINAPI NtQueryObjectRaw(LPVOID param);
-	WuResult NtQueryObjectWithTimeout(HANDLE hObject, OBJECT_INFORMATION_CLASS objInfoClass, PVOID objectInfo, ULONG timeout);
-	WuResult GetProcessImageName(DWORD processId, WWuString& imageName);
+	void NtQueryObjectWithTimeout(HANDLE hObject, OBJECT_INFORMATION_CLASS objInfoClass, wuunique_ptr<BYTE[]>& objectInfo, ULONG timeout);
+	void GetProcessImageName(DWORD processId, WWuString& imageName);
 }

--- a/src/ClrCore/Headers/ProcessAndThread.h
+++ b/src/ClrCore/Headers/ProcessAndThread.h
@@ -21,23 +21,36 @@ namespace WindowsUtils::Core
 			ProductName = 2U,
 			FileVersion = 3U,
 			CompanyName = 4U
-
 		} VERSION_INFO_PROPERTY;
+
+		typedef enum _SUPPORTED_OBJECT_TYPE
+		{
+			FileSystem = 0,
+			Registry = 1
+		} SUPPORTED_OBJECT_TYPE;
+
+		typedef struct _OBJECT_INPUT
+		{
+			WWuString ObjectName;
+			SUPPORTED_OBJECT_TYPE Type;
+
+		} OBJECT_INPUT, *POBJECT_INPUT;
 
 		typedef struct _WU_OBJECT_HANDLE
 		{
-			WWuString		InputObject;									// Input object path. Helps tracking which handle belongs to which object, when querying multiple objects.
-			DWORD			ProcessId;										// ID from the process owning the handle.
-			WWuString		Name;											// Process image name. File base name.
-			WWuString		ImagePath;										// Process image path.
-			wumap<VERSION_INFO_PROPERTY, const WWuString> VersionInfo;		// Image version information.
+			SUPPORTED_OBJECT_TYPE	Type;								// The path type. 'FileSystem' or 'Registry'.
+			WWuString				InputObject;						// Input object path. Helps tracking which handle belongs to which object, when querying multiple objects.
+			DWORD					ProcessId;							// ID from the process owning the handle.
+			WWuString				Name;								// Process image name. File base name.
+			WWuString				ImagePath;							// Process image path.
+			wumap<VERSION_INFO_PROPERTY, const WWuString> VersionInfo;	// Image version information.
 
 			_WU_OBJECT_HANDLE()
 				: InputObject(), ProcessId(0), Name(), ImagePath(), VersionInfo()
 			{ }
 			
-			_WU_OBJECT_HANDLE(const WWuString& inputObj, DWORD pid, const WWuString& name, const WWuString& imagePath, const wumap<VERSION_INFO_PROPERTY, const WWuString>& versionInfo)
-				: InputObject(inputObj), ProcessId(pid), Name(name), ImagePath(imagePath), VersionInfo(versionInfo)
+			_WU_OBJECT_HANDLE(SUPPORTED_OBJECT_TYPE type, const WWuString& inputObj, DWORD pid, const WWuString& name, const WWuString& imagePath, const wumap<VERSION_INFO_PROPERTY, const WWuString>& versionInfo)
+				: Type(type), InputObject(inputObj), ProcessId(pid), Name(name), ImagePath(imagePath), VersionInfo(versionInfo)
 			{ }
 
 			~_WU_OBJECT_HANDLE() { }
@@ -49,7 +62,7 @@ namespace WindowsUtils::Core
 		===========================================*/
 
 		// Get-ObjectHandle
-		WuResult GetProcessObjectHandle(wuvector<WU_OBJECT_HANDLE>* objectHandleList, wuvector<WWuString>* resList, BOOL closeHandle);
+		void GetProcessObjectHandle(wuvector<WU_OBJECT_HANDLE>* objectHandleList, wuvector<OBJECT_INPUT>* inputList, bool closeHandle);
 	};
 
 	/*=========================================
@@ -57,5 +70,5 @@ namespace WindowsUtils::Core
 	===========================================*/
 
 	WuResult GetProccessVersionInfo(const WWuString& imagePath, ProcessAndThread::VERSION_INFO_PROPERTY propertyName, WWuString& value);
-	WuResult CloseExtProcessHandle(HANDLE sourceProcess, const WWuString& objectName);
+	void CloseExtProcessHandle(HANDLE sourceProcess, const WWuString& objectName);
 }

--- a/src/ClrCore/Headers/Wrapper.h
+++ b/src/ClrCore/Headers/Wrapper.h
@@ -177,9 +177,16 @@ namespace WindowsUtils::Core
 	};
 
 	// Get-ObjectHandle
+	public enum class ObjectHandleType
+	{
+		FileSystem = 0,
+		Registry = 1
+	};
+
 	public ref class ObjectHandleBase
 	{
 	public:
+		property ObjectHandleType Type { ObjectHandleType get() { return static_cast<ObjectHandleType>(wrapper->Type); } }
 		property String^ InputObject { String^ get() { return gcnew String(wrapper->InputObject.GetBuffer()); } }
 		property String^ Name {
 			String^ get()
@@ -275,6 +282,20 @@ namespace WindowsUtils::Core
 
 	private:
 		ProcessAndThread::PWU_OBJECT_HANDLE wrapper;
+	};
+
+	public ref class ObjectHandleInput
+	{
+	public:
+		property String^ Path { String^ get() { return m_Path; } }
+		property ObjectHandleType Type { ObjectHandleType get() { return m_Type; } }
+
+		ObjectHandleInput(String^ path, ObjectHandleType type)
+			: m_Path(path), m_Type(type) { }
+
+	private:
+		String^ m_Path;
+		ObjectHandleType m_Type;
 	};
 
 	// Get-ResourceMessageTable
@@ -397,7 +418,7 @@ namespace WindowsUtils::Core
 		String^ GetLastWin32Error();
 
 		// Get-ObjectHandle
-		array<ObjectHandleBase^>^ GetProcessObjectHandle(array<String^>^ fileName, Boolean closeHandle);
+		array<ObjectHandleBase^>^ GetProcessObjectHandle(array<ObjectHandleInput^>^ inputList, Boolean closeHandle);
 
 		// Send-Click
 		Void SendClick();

--- a/src/ClrCore/pch.h
+++ b/src/ClrCore/pch.h
@@ -76,6 +76,6 @@
 #include <time.h>
 #include <windns.h>
 #include <sysinfoapi.h>
-#include <processthreadsapi.h>
+#include <TlHelp32.h>
 
 #endif //PCH_H

--- a/src/Engine/Common.cs
+++ b/src/Engine/Common.cs
@@ -163,6 +163,7 @@ namespace WindowsUtils
     /// </summary>
     public class ObjectHandle
     {
+        public ObjectHandleType Type => wrapper.Type;
         public string InputObject => wrapper.InputObject;
         public string Name => wrapper.Name;
         public uint ProcessId => wrapper.ProcessId;

--- a/src/Engine/Interop.cs
+++ b/src/Engine/Interop.cs
@@ -4,6 +4,21 @@ using Microsoft.Win32.SafeHandles;
 
 namespace WindowsUtils.Interop
 {
+    internal enum KEY_INFORMATION_CLASS
+    {
+        KeyBasicInformation,
+        KeyNodeInformation,
+        KeyFullInformation,
+        KeyNameInformation,
+        KeyCachedInformation,
+        KeyFlagsInformation,
+        KeyVirtualizationInformation,
+        KeyHandleTagsInformation,
+        KeyTrustInformation,
+        KeyLayerInformation,
+        MaxKeyInfoClass
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     internal struct LARGE_INTEGER
     {
@@ -46,6 +61,15 @@ namespace WindowsUtils.Interop
                 ((uint)(quadPart & 0xFFFFFFFF), (uint)(quadPart & 0xFFFFFFFF00000000), quadPart);
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct KEY_NAME_INFORMATION
+    {
+        internal uint NameLength;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        internal string Name;
+    }
+
     public class SafeSystemHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeSystemHandle() : base(true) { }
@@ -76,8 +100,17 @@ namespace WindowsUtils.Interop
 
     internal partial class NativeFunctions
     {
+        [DllImport("ntdll.dll", SetLastError = true)]
+        internal static extern int NtQueryKey(
+            IntPtr KeyHandle,
+            KEY_INFORMATION_CLASS KeyInformationClass,
+            IntPtr KeyInformation,
+            int Length,
+            out int ResultLength
+        );
+
         [DllImport("kernel32", SetLastError = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-        internal extern static bool CloseHandle(IntPtr handle);
+        internal static extern bool CloseHandle(IntPtr handle);
     }
 }

--- a/src/Engine/Utils.cs
+++ b/src/Engine/Utils.cs
@@ -1,63 +1,103 @@
 ﻿using System.Security;
 using System.Security.Principal;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+using System.Runtime.CompilerServices;
+using WindowsUtils.Core;
 
-namespace WindowsUtils;
-
-public static class Utils
+namespace WindowsUtils
 {
-    public static bool TryGetWindowsCurrentIdentity(out WindowsIdentity? currentIdentity)
+    public static class Utils
     {
-        try
+        public static bool TryGetWindowsCurrentIdentity(out WindowsIdentity? currentIdentity)
         {
-            currentIdentity = WindowsIdentity.GetCurrent();
-        }
-        catch (SecurityException)
-        {
-            
-            currentIdentity = null;
-        }
-
-        return currentIdentity != null;
-    }
-
-    public static bool IsAdministrator()
-    {
-        if (TryGetWindowsCurrentIdentity(out WindowsIdentity? currentIdentity))
-        {
-            if (currentIdentity is null)
-                return false;
-
-            WindowsPrincipal principal = new(currentIdentity);
-            return principal.IsInRole(WindowsBuiltInRole.Administrator);
-        }
-
-        return false;
-    }
-
-    internal static SecureString ReadPassword()
-    {
-        var pwd = new SecureString();
-        while (true)
-        {
-            ConsoleKeyInfo i = Console.ReadKey(true);
-            if (i.Key == ConsoleKey.Enter)
+            try
             {
-                break;
+                currentIdentity = WindowsIdentity.GetCurrent();
             }
-            else if (i.Key == ConsoleKey.Backspace)
+            catch (SecurityException)
             {
-                if (pwd.Length > 0)
+
+                currentIdentity = null;
+            }
+
+            return currentIdentity != null;
+        }
+
+        public static bool IsAdministrator()
+        {
+            if (TryGetWindowsCurrentIdentity(out WindowsIdentity? currentIdentity))
+            {
+                if (currentIdentity is null)
+                    return false;
+
+                WindowsPrincipal principal = new(currentIdentity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+
+            return false;
+        }
+
+        internal static SecureString ReadPassword()
+        {
+            var pwd = new SecureString();
+            while (true)
+            {
+                ConsoleKeyInfo i = Console.ReadKey(true);
+                if (i.Key == ConsoleKey.Enter)
                 {
-                    pwd.RemoveAt(pwd.Length - 1);
-                    Console.Write("\b \b");
+                    break;
+                }
+                else if (i.Key == ConsoleKey.Backspace)
+                {
+                    if (pwd.Length > 0)
+                    {
+                        pwd.RemoveAt(pwd.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                }
+                // KeyChar == '\u0000' if the key pressed does not correspond to a printable character, e.g. F1, Pause-Break, etc
+                else if (i.KeyChar != '\u0000')
+                {
+                    pwd.AppendChar(i.KeyChar);
+                    Console.Write("*");
                 }
             }
-            else if (i.KeyChar != '\u0000') // KeyChar == '\u0000' if the key pressed does not correspond to a printable character, e.g. F1, Pause-Break, etc
-            {
-                pwd.AppendChar(i.KeyChar);
-                Console.Write("*");
-            }
+            return pwd;
         }
-        return pwd;
+
+        internal static string? GetRegistryNtPath(string keyPath)
+        {
+            string[] splitPath = keyPath.Split('\\');
+            string subkeyPath = string.Join("\\", new ArraySegment<string>(splitPath, 1, splitPath.Length - 1));
+
+            int bufferSize = 1 << 10;
+            IntPtr buffer = Marshal.AllocHGlobal(bufferSize);
+            RegistryKey hiveKey = splitPath[0] switch {
+                "HKEY_CLASSES_ROOT" => Microsoft.Win32.Registry.ClassesRoot,
+                "HKEY_CURRENT_USER" => Microsoft.Win32.Registry.CurrentUser,
+                "HKEY_LOCAL_MACHINE" => Microsoft.Win32.Registry.LocalMachine,
+                "HKEY_USERS" => Microsoft.Win32.Registry.Users,
+                "HKEY_CURRENT_CONFIG" => Microsoft.Win32.Registry.CurrentConfig,
+                _ => throw new ArgumentException($"Invalid hive '{splitPath[0]}'."),
+            };
+
+            using (RegistryKey? keyHandle = hiveKey.OpenSubKey(subkeyPath))
+            {
+                if (keyHandle is null)
+                    return null;
+
+                int result = Interop.NativeFunctions.NtQueryKey(keyHandle.Handle.DangerousGetHandle(), Interop.KEY_INFORMATION_CLASS.KeyNameInformation, buffer, bufferSize, out bufferSize);
+                if (result != 0)
+                    throw new NativeException(result);
+            }
+
+            char[] bytes = new char[2 + bufferSize + 2];
+            Marshal.Copy(buffer, bytes, 0, bufferSize);
+            // startIndex == 2  skips the NameLength field of the structure (2 chars == 4 bytes)
+            // needed/2         reduces value from bytes to chars
+            //  needed/2 - 2    reduces length to not include the NameLength
+            return new(bytes, 2, (bufferSize / 2) - 2);
+        }
     }
 }

--- a/src/WindowsUtils.csproj
+++ b/src/WindowsUtils.csproj
@@ -4,7 +4,7 @@
 	<TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.7.0</Version>
+    <Version>1.8.2</Version>
     <Authors>FranciscoNabas</Authors>
     <Platforms>x64</Platforms>
     <AssemblyName></AssemblyName>

--- a/src/obj/WindowsUtils.csproj.nuget.dgspec.json
+++ b/src/obj/WindowsUtils.csproj.nuget.dgspec.json
@@ -1,32 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {}
+    "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {}
   },
   "projects": {
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+    "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {
+      "version": "1.8.2",
       "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
-        "projectName": "WuCore",
-        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
-        "frameworks": {
-          "native": {
-            "projectReferences": {}
-          }
-        }
-      },
-      "frameworks": {
-        "native": {}
-      }
-    },
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {
-      "version": "1.7.0",
-      "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectUniqueName": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "projectName": "WindowsUtils",
-        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-        "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
+        "outputPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
         "projectStyle": "PackageReference",
         "crossTargeting": true,
         "fallbackFolders": [
@@ -48,19 +33,11 @@
         "frameworks": {
           "net472": {
             "targetAlias": "net472",
-            "projectReferences": {
-              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-              }
-            }
+            "projectReferences": {}
           },
           "netstandard2.0": {
             "targetAlias": "netstandard2.0",
-            "projectReferences": {
-              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-              }
-            }
+            "projectReferences": {}
           }
         },
         "warningProperties": {

--- a/src/obj/WindowsUtils.csproj.nuget.dgspec.json
+++ b/src/obj/WindowsUtils.csproj.nuget.dgspec.json
@@ -1,14 +1,14 @@
 {
   "format": 1,
   "restore": {
-    "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj": {}
+    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {}
   },
   "projects": {
-    "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+    "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
       "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
+        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
         "projectName": "WuCore",
-        "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
+        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
         "frameworks": {
           "native": {
             "projectReferences": {}
@@ -19,18 +19,22 @@
         "native": {}
       }
     },
-    "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj": {
+    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {
       "version": "1.7.0",
       "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "projectName": "WindowsUtils",
-        "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-        "outputPath": "C:\\LocalRepositories\\WindowsUtils\\src\\obj\\",
+        "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
         "projectStyle": "PackageReference",
         "crossTargeting": true,
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
         "configFilePaths": [
           "C:\\Users\\francisco.nabas\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
           "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
         ],
         "originalTargetFrameworks": [
@@ -45,16 +49,16 @@
           "net472": {
             "targetAlias": "net472",
             "projectReferences": {
-              "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
+              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
               }
             }
           },
           "netstandard2.0": {
             "targetAlias": "netstandard2.0",
             "projectReferences": {
-              "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
+              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
               }
             }
           }
@@ -63,6 +67,9 @@
           "warnAsError": [
             "NU1605"
           ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "default"
         }
       },
       "frameworks": {
@@ -104,7 +111,7 @@
               "version": "[0.3.0, )"
             }
           },
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\7.0.304\\RuntimeIdentifierGraph.json"
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
         },
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
@@ -161,7 +168,7 @@
           ],
           "assetTargetFallback": true,
           "warn": true,
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\7.0.304\\RuntimeIdentifierGraph.json"
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
         }
       }
     }

--- a/src/obj/WindowsUtils.csproj.nuget.g.props
+++ b/src/obj/WindowsUtils.csproj.nuget.g.props
@@ -5,12 +5,13 @@
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
     <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\francisco.nabas\.nuget\packages\</NuGetPackageFolders>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\francisco.nabas\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
-    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.6.0</NuGetToolVersion>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.8.0</NuGetToolVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <SourceRoot Include="C:\Users\francisco.nabas\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(ExcludeRestorePackageImports)' != 'true' ">
     <PkgXmlDoc2CmdletDoc Condition=" '$(PkgXmlDoc2CmdletDoc)' == '' ">C:\Users\francisco.nabas\.nuget\packages\xmldoc2cmdletdoc\0.3.0</PkgXmlDoc2CmdletDoc>

--- a/src/obj/project.assets.json
+++ b/src/obj/project.assets.json
@@ -1515,20 +1515,25 @@
     ]
   },
   "packageFolders": {
-    "C:\\Users\\francisco.nabas\\.nuget\\packages\\": {}
+    "C:\\Users\\francisco.nabas\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
     "version": "1.7.0",
     "restore": {
-      "projectUniqueName": "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "projectName": "WindowsUtils",
-      "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-      "outputPath": "C:\\LocalRepositories\\WindowsUtils\\src\\obj\\",
+      "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
       "projectStyle": "PackageReference",
       "crossTargeting": true,
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
       "configFilePaths": [
         "C:\\Users\\francisco.nabas\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
         "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
       ],
       "originalTargetFrameworks": [
@@ -1543,16 +1548,16 @@
         "net472": {
           "targetAlias": "net472",
           "projectReferences": {
-            "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
+            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
             }
           }
         },
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
           "projectReferences": {
-            "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
+            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
             }
           }
         }
@@ -1561,6 +1566,9 @@
         "warnAsError": [
           "NU1605"
         ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "default"
       }
     },
     "frameworks": {
@@ -1602,7 +1610,7 @@
             "version": "[0.3.0, )"
           }
         },
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\7.0.304\\RuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
       },
       "netstandard2.0": {
         "targetAlias": "netstandard2.0",
@@ -1659,7 +1667,7 @@
         ],
         "assetTargetFallback": true,
         "warn": true,
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\7.0.304\\RuntimeIdentifierGraph.json"
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
       }
     }
   }

--- a/src/obj/project.assets.json
+++ b/src/obj/project.assets.json
@@ -311,15 +311,6 @@
         "build": {
           "build/XmlDoc2CmdletDoc.targets": {}
         }
-      },
-      "WuCore/1.0.0": {
-        "type": "project",
-        "compile": {
-          "bin/placeholder/WuCore.dll": {}
-        },
-        "runtime": {
-          "bin/placeholder/WuCore.dll": {}
-        }
       }
     },
     ".NETStandard,Version=v2.0": {
@@ -624,15 +615,6 @@
         "type": "package",
         "build": {
           "build/XmlDoc2CmdletDoc.targets": {}
-        }
-      },
-      "WuCore/1.0.0": {
-        "type": "project",
-        "compile": {
-          "bin/placeholder/WuCore.dll": {}
-        },
-        "runtime": {
-          "bin/placeholder/WuCore.dll": {}
         }
       }
     }
@@ -1482,11 +1464,6 @@
         "xmldoc2cmdletdoc.0.3.0.nupkg.sha512",
         "xmldoc2cmdletdoc.nuspec"
       ]
-    },
-    "WuCore/1.0.0": {
-      "type": "project",
-      "path": "ClrCore/WuCore.vcxproj",
-      "msbuildProject": "ClrCore/WuCore.vcxproj"
     }
   },
   "projectFileDependencyGroups": {
@@ -1498,7 +1475,6 @@
       "System.Security.Principal.Windows >= 5.0.0",
       "System.ServiceProcess.ServiceController >= 7.0.1",
       "System.Text.Json >= 7.0.3",
-      "WuCore >= 1.0.0",
       "XmlDoc2CmdletDoc >= 0.3.0"
     ],
     ".NETStandard,Version=v2.0": [
@@ -1510,7 +1486,6 @@
       "System.Security.Principal.Windows >= 5.0.0",
       "System.ServiceProcess.ServiceController >= 7.0.1",
       "System.Text.Json >= 7.0.3",
-      "WuCore >= 1.0.0",
       "XmlDoc2CmdletDoc >= 0.3.0"
     ]
   },
@@ -1519,13 +1494,13 @@
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
-    "version": "1.7.0",
+    "version": "1.8.2",
     "restore": {
-      "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectUniqueName": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "projectName": "WindowsUtils",
-      "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-      "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
+      "outputPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
       "projectStyle": "PackageReference",
       "crossTargeting": true,
       "fallbackFolders": [
@@ -1547,19 +1522,11 @@
       "frameworks": {
         "net472": {
           "targetAlias": "net472",
-          "projectReferences": {
-            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-            }
-          }
+          "projectReferences": {}
         },
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
-          "projectReferences": {
-            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-            }
-          }
+          "projectReferences": {}
         }
       },
       "warningProperties": {

--- a/src/obj/project.nuget.cache
+++ b/src/obj/project.nuget.cache
@@ -1,8 +1,8 @@
 {
   "version": 2,
-  "dgSpecHash": "lkd+gzFcatV1kFI81eiQAL9tMJ6aSKYj3sgo+GEdYhr+cBeF8XYq1FOLhHRcPQ+3heF5Mf7R51mgBPZNtnwvHQ==",
+  "dgSpecHash": "tv82oamLapocjyRs4i3eoV08aH55GVYTAKPOpjQk61QoXyM+FayAplUXT/22vK0ZQXaAHFn+EAUKoGPuJH0tVA==",
   "success": true,
-  "projectFilePath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+  "projectFilePath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
   "expectedPackageFiles": [
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.bcl.asyncinterfaces\\7.0.0\\microsoft.bcl.asyncinterfaces.7.0.0.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.netcore.platforms\\1.1.0\\microsoft.netcore.platforms.1.1.0.nupkg.sha512",

--- a/src/obj/project.nuget.cache
+++ b/src/obj/project.nuget.cache
@@ -1,8 +1,8 @@
 {
   "version": 2,
-  "dgSpecHash": "sSbVomkR0LHTYsHV7yzTbTgD+cndauDPZ14Xm6VZoTWisS+M0z7Gq0WE221BpZvjgFi5bPx8jVFGLtpjOVoEpA==",
+  "dgSpecHash": "lkd+gzFcatV1kFI81eiQAL9tMJ6aSKYj3sgo+GEdYhr+cBeF8XYq1FOLhHRcPQ+3heF5Mf7R51mgBPZNtnwvHQ==",
   "success": true,
-  "projectFilePath": "C:\\LocalRepositories\\WindowsUtils\\src\\WindowsUtils.csproj",
+  "projectFilePath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
   "expectedPackageFiles": [
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.bcl.asyncinterfaces\\7.0.0\\microsoft.bcl.asyncinterfaces.7.0.0.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.netcore.platforms\\1.1.0\\microsoft.netcore.platforms.1.1.0.nupkg.sha512",


### PR DESCRIPTION
- Get-ObjectHandle.
  Proudly announce that `Get-ObjectHandle` now returns handles opened for registry keys, with full
  provider awareness.

- Get-ObjectHandle.
  Improved the provider awareness both to support registry keys, and handle unsupported PS providers.