### PR TITLE
Get-ObjectHandle bugs

### DIFF
--- a/Tools/PSModule/WindowsUtils.psd1
+++ b/Tools/PSModule/WindowsUtils.psd1
@@ -1,6 +1,6 @@
 @{
     GUID = 'C5F7B91E-668D-46AC-9F0E-23B0A74ABCBA'
-    ModuleVersion = '1.8.2'
+    ModuleVersion = '1.8.3'
     RootModule = 'WindowsUtils.dll'
     CompatiblePSEditions = @(
         'Desktop',

--- a/src/ClrCore/Headers/NtUtilities.h
+++ b/src/ClrCore/Headers/NtUtilities.h
@@ -23,6 +23,21 @@ namespace WindowsUtils::Core
 	* https://github.com/winsiderss/systeminformer
 	*/
 
+	typedef enum _KEY_INFORMATION_CLASS
+	{
+		KeyBasicInformation,
+		KeyNodeInformation,
+		KeyFullInformation,
+		KeyNameInformation,
+		KeyCachedInformation,
+		KeyFlagsInformation,
+		KeyVirtualizationInformation,
+		KeyHandleTagsInformation,
+		KeyTrustInformation,
+		KeyLayerInformation,
+		MaxKeyInfoClass
+	} KEY_INFORMATION_CLASS;
+	
 	// Objects
 
 	typedef enum _OBJECT_INFORMATION_CLASS {
@@ -159,6 +174,12 @@ namespace WindowsUtils::Core
 		LARGE_INTEGER OtherTransferCount;
 		SYSTEM_THREAD_INFORMATION Threads[1]; // SystemProcessInformation
 	} SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
+
+	typedef struct _KEY_NAME_INFORMATION
+	{
+		ULONG NameLength;
+		WCHAR Name[1];
+	} KEY_NAME_INFORMATION, *PKEY_NAME_INFORMATION;
 	
 	// Procedures
 
@@ -201,6 +222,14 @@ namespace WindowsUtils::Core
 		PVOID						SystemInformation,
 		ULONG						SystemInformationLength,
 		PULONG						ReturnLength
+	);
+
+	typedef NTSTATUS(NTAPI* _NtQueryKey)(
+		__in HANDLE					KeyHandle,
+		__in KEY_INFORMATION_CLASS	KeyInformationClass,
+		__out_opt PVOID				KeyInformation,
+		__in ULONG					Length,
+		__out PULONG				ResultLength
 	);
 
 	typedef __kernel_entry NTSTATUS(NTAPI* _NtQuerySystemTime)(__out PLARGE_INTEGER SystemTime);

--- a/src/ClrCore/Headers/Wrapper.h
+++ b/src/ClrCore/Headers/Wrapper.h
@@ -431,6 +431,9 @@ namespace WindowsUtils::Core
 		// Start-ProcessAsUser
 		void StartProcessAsUser(String^ userName, String^ domain, SecureString^ password, String^ commandLine, String^ titleBar);
 
+		// Utilities
+		static String^ GetRegistryNtPath(String^ keyPath);
+
 	private:
 		Utilities* utlptr;
 		TerminalServices* wtsptr;

--- a/src/ClrCore/SourceFiles/NtUtilities.cpp
+++ b/src/ClrCore/SourceFiles/NtUtilities.cpp
@@ -111,7 +111,7 @@ namespace WindowsUtils::Core
 					continue;
 
 				wuunique_ptr<BYTE[]> nameBuffer;
-				NtQueryObjectWithTimeout(hTarget, ObjectNameInformation, nameBuffer, 200);
+				NtQueryObjectWithTimeout(hTarget, ObjectNameInformation, nameBuffer, 50);
 				CloseHandle(hTarget);
 
 				auto nameInfo = reinterpret_cast<POBJECT_NAME_INFORMATION>(nameBuffer.get());

--- a/src/ClrCore/SourceFiles/ProcessAndThread.cpp
+++ b/src/ClrCore/SourceFiles/ProcessAndThread.cpp
@@ -248,7 +248,7 @@ namespace WindowsUtils::Core
 			if (!DuplicateHandle(hExtProcess, phsnapinfo->Handles[i].HandleValue, ::GetCurrentProcess(), &hTarget, 0, FALSE, DUPLICATE_SAME_ACCESS))
 				continue;
 
-			NtQueryObjectWithTimeout(hTarget, ObjectNameInformation, objectNameBuffer, 200);
+			NtQueryObjectWithTimeout(hTarget, ObjectNameInformation, objectNameBuffer, 50);
 
 			CloseHandle(hTarget);
 

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -469,7 +469,7 @@ namespace WindowsUtils.Commands
                             break;
 
                         case "Registry":
-                            string? ntPath = Utils.GetRegistryNtPath(singlePath);
+                            string? ntPath = Wrapper.GetRegistryNtPath(singlePath);
                             if (ntPath is not null)
                             {
                                 // Console.WriteLine(ntPath);

--- a/src/Engine/AccessControl.cs
+++ b/src/Engine/AccessControl.cs
@@ -28,6 +28,54 @@ namespace WindowsUtils.Interop
         GENERIC_ALL = 0x10000000
     }
 
+    [Flags]
+    internal enum TokenAccessRight : uint
+    {
+        TOKEN_ASSIGN_PRIMARY = 0x0001,
+        TOKEN_DUPLICATE = 0x0002,
+        TOKEN_IMPERSONATE = 0x0004,
+        TOKEN_QUERY = 0x0008,
+        TOKEN_QUERY_SOURCE = 0x0010,
+        TOKEN_ADJUST_PRIVILEGES = 0x0020,
+        TOKEN_ADJUST_GROUPS = 0x0040,
+        TOKEN_ADJUST_DEFAULT = 0x0080,
+        TOKEN_ADJUST_SESSIONID = 0x0100,
+        TOKEN_ALL_ACCESS_P = AccessType.STANDARD_RIGHTS_REQUIRED |
+                             TOKEN_ASSIGN_PRIMARY |
+                             TOKEN_DUPLICATE |
+                             TOKEN_IMPERSONATE |
+                             TOKEN_QUERY |
+                             TOKEN_QUERY_SOURCE |
+                             TOKEN_ADJUST_PRIVILEGES |
+                             TOKEN_ADJUST_GROUPS |
+                             TOKEN_ADJUST_DEFAULT,
+
+        // #if ((defined(_WIN32_WINNT) && (_WIN32_WINNT > 0x0400)) || (!defined(_WIN32_WINNT)))
+        TOKEN_ALL_ACCESS = TOKEN_ALL_ACCESS_P | TOKEN_ADJUST_SESSIONID,
+        // #else
+        // #define TOKEN_ALL_ACCESS TOKEN_ALL_ACCESS_P
+        // #endif
+        TOKEN_READ = AccessType.STANDARD_RIGHTS_READ | TOKEN_QUERY,
+        TOKEN_WRITE = AccessType.STANDARD_RIGHTS_WRITE |
+                      TOKEN_ADJUST_PRIVILEGES |
+                      TOKEN_ADJUST_GROUPS |
+                      TOKEN_ADJUST_DEFAULT,
+
+        TOKEN_EXECUTE = AccessType.STANDARD_RIGHTS_EXECUTE,
+        TOKEN_TRUST_CONSTRAINT_MASK = AccessType.STANDARD_RIGHTS_READ |
+                                      TOKEN_QUERY |
+                                      TOKEN_QUERY_SOURCE,
+
+        TOKEN_TRUST_ALLOWED_MASK = TOKEN_TRUST_CONSTRAINT_MASK |
+                                   TOKEN_DUPLICATE |
+                                   TOKEN_IMPERSONATE,
+
+        // #if (NTDDI_VERSION >= NTDDI_WIN8)
+        TOKEN_ACCESS_PSEUDO_HANDLE_WIN8 = TOKEN_QUERY | TOKEN_QUERY_SOURCE,
+        TOKEN_ACCESS_PSEUDO_HANDLE = TOKEN_ACCESS_PSEUDO_HANDLE_WIN8
+        // #endif
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     internal struct SECURITY_ATTRIBUTES
     {

--- a/src/Engine/Interop.cs
+++ b/src/Engine/Interop.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
 using Microsoft.Win32.SafeHandles;
+using System.Text;
 
 namespace WindowsUtils.Interop
 {
@@ -17,6 +18,19 @@ namespace WindowsUtils.Interop
         KeyTrustInformation,
         KeyLayerInformation,
         MaxKeyInfoClass
+    }
+
+    internal enum SID_NAME_USE
+    {
+        SidTypeUser = 1,
+        SidTypeGroup,
+        SidTypeDomain,
+        SidTypeAlias,
+        SidTypeWellKnownGroup,
+        SidTypeDeletedAccount,
+        SidTypeInvalid,
+        SidTypeUnknown,
+        SidTypeComputer
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -96,6 +110,9 @@ namespace WindowsUtils.Interop
     internal partial class NativeConstants
     {
         internal static readonly IntPtr INVALID_HANDLE_VALUE = (IntPtr)(-1);
+        internal const int ERROR_INSUFFICIENT_BUFFER = 122;
+        internal const int ERROR_INVALID_FLAGS = 1004;
+        internal const int ERROR_SUCCESS = 0;
     }
 
     internal partial class NativeFunctions
@@ -107,6 +124,24 @@ namespace WindowsUtils.Interop
             IntPtr KeyInformation,
             int Length,
             out int ResultLength
+        );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool LookupAccountName(
+            string lpSystemName,
+            string lpAccountName,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] Sid,
+            ref uint cbSid,
+            StringBuilder ReferencedDomainName,
+            ref uint cchReferencedDomainName,
+            out SID_NAME_USE peUse
+        );
+
+        [DllImport("advapi32", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool CheckTokenMembership(
+            IntPtr tokenHandle,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] Sid,
+            out bool isMember
         );
 
         [DllImport("kernel32", SetLastError = true)]

--- a/src/WindowsUtils.csproj
+++ b/src/WindowsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>1.8.2</Version>
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="XmlDoc2CmdletDoc" Version="0.3.0">

--- a/src/WindowsUtils.csproj
+++ b/src/WindowsUtils.csproj
@@ -4,7 +4,7 @@
 	<TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.8.2</Version>
+    <Version>1.8.3</Version>
     <Authors>FranciscoNabas</Authors>
     <Platforms>x64</Platforms>
     <AssemblyName></AssemblyName>

--- a/src/obj/WindowsUtils.csproj.nuget.dgspec.json
+++ b/src/obj/WindowsUtils.csproj.nuget.dgspec.json
@@ -38,7 +38,6 @@
           "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
         ],
         "originalTargetFrameworks": [
-          "net472",
           "netstandard2.0"
         ],
         "sources": {
@@ -46,14 +45,6 @@
           "https://api.nuget.org/v3/index.json": {}
         },
         "frameworks": {
-          "net472": {
-            "targetAlias": "net472",
-            "projectReferences": {
-              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-              }
-            }
-          },
           "netstandard2.0": {
             "targetAlias": "netstandard2.0",
             "projectReferences": {
@@ -73,46 +64,6 @@
         }
       },
       "frameworks": {
-        "net472": {
-          "targetAlias": "net472",
-          "dependencies": {
-            "Microsoft.Win32.Primitives": {
-              "target": "Package",
-              "version": "[4.3.0, )"
-            },
-            "Microsoft.Win32.Registry": {
-              "target": "Package",
-              "version": "[5.0.0, )"
-            },
-            "PowerShellStandard.Library": {
-              "target": "Package",
-              "version": "[5.1.1, )"
-            },
-            "System.Security.AccessControl": {
-              "target": "Package",
-              "version": "[6.0.0, )"
-            },
-            "System.Security.Principal.Windows": {
-              "target": "Package",
-              "version": "[5.0.0, )"
-            },
-            "System.ServiceProcess.ServiceController": {
-              "target": "Package",
-              "version": "[7.0.1, )"
-            },
-            "System.Text.Json": {
-              "target": "Package",
-              "version": "[7.0.3, )"
-            },
-            "XmlDoc2CmdletDoc": {
-              "include": "Runtime, Build, Native, ContentFiles, Analyzers, BuildTransitive",
-              "suppressParent": "All",
-              "target": "Package",
-              "version": "[0.3.0, )"
-            }
-          },
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
-        },
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
           "dependencies": {
@@ -137,10 +88,6 @@
             "System.Security.AccessControl": {
               "target": "Package",
               "version": "[6.0.0, )"
-            },
-            "System.Security.Principal.Windows": {
-              "target": "Package",
-              "version": "[5.0.0, )"
             },
             "System.ServiceProcess.ServiceController": {
               "target": "Package",

--- a/src/obj/WindowsUtils.csproj.nuget.dgspec.json
+++ b/src/obj/WindowsUtils.csproj.nuget.dgspec.json
@@ -1,32 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {}
+    "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {}
   },
   "projects": {
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
+    "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {
+      "version": "1.8.3",
       "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
-        "projectName": "WuCore",
-        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj",
-        "frameworks": {
-          "native": {
-            "projectReferences": {}
-          }
-        }
-      },
-      "frameworks": {
-        "native": {}
-      }
-    },
-    "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj": {
-      "version": "1.8.2",
-      "restore": {
-        "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectUniqueName": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "projectName": "WindowsUtils",
-        "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+        "projectPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
         "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-        "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
+        "outputPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
         "projectStyle": "PackageReference",
         "crossTargeting": true,
         "fallbackFolders": [
@@ -47,11 +32,7 @@
         "frameworks": {
           "netstandard2.0": {
             "targetAlias": "netstandard2.0",
-            "projectReferences": {
-              "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-                "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-              }
-            }
+            "projectReferences": {}
           }
         },
         "warningProperties": {

--- a/src/obj/WindowsUtils.csproj.nuget.g.props
+++ b/src/obj/WindowsUtils.csproj.nuget.g.props
@@ -13,9 +13,6 @@
     <SourceRoot Include="C:\Users\francisco.nabas\.nuget\packages\" />
     <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(ExcludeRestorePackageImports)' != 'true' ">
-    <PkgXmlDoc2CmdletDoc Condition=" '$(PkgXmlDoc2CmdletDoc)' == '' ">C:\Users\francisco.nabas\.nuget\packages\xmldoc2cmdletdoc\0.3.0</PkgXmlDoc2CmdletDoc>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' AND '$(ExcludeRestorePackageImports)' != 'true' ">
     <PkgXmlDoc2CmdletDoc Condition=" '$(PkgXmlDoc2CmdletDoc)' == '' ">C:\Users\francisco.nabas\.nuget\packages\xmldoc2cmdletdoc\0.3.0</PkgXmlDoc2CmdletDoc>
   </PropertyGroup>

--- a/src/obj/WindowsUtils.csproj.nuget.g.targets
+++ b/src/obj/WindowsUtils.csproj.nuget.g.targets
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Condition=" '$(TargetFramework)' == 'net472' AND '$(ExcludeRestorePackageImports)' != 'true' ">
-    <Import Project="$(NuGetPackageRoot)xmldoc2cmdletdoc\0.3.0\build\XmlDoc2CmdletDoc.targets" Condition="Exists('$(NuGetPackageRoot)xmldoc2cmdletdoc\0.3.0\build\XmlDoc2CmdletDoc.targets')" />
-    <Import Project="$(NuGetPackageRoot)system.text.json\7.0.3\buildTransitive\net462\System.Text.Json.targets" Condition="Exists('$(NuGetPackageRoot)system.text.json\7.0.3\buildTransitive\net462\System.Text.Json.targets')" />
-  </ImportGroup>
   <ImportGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' AND '$(ExcludeRestorePackageImports)' != 'true' ">
     <Import Project="$(NuGetPackageRoot)xmldoc2cmdletdoc\0.3.0\build\XmlDoc2CmdletDoc.targets" Condition="Exists('$(NuGetPackageRoot)xmldoc2cmdletdoc\0.3.0\build\XmlDoc2CmdletDoc.targets')" />
     <Import Project="$(NuGetPackageRoot)system.text.json\7.0.3\buildTransitive\netstandard2.0\System.Text.Json.targets" Condition="Exists('$(NuGetPackageRoot)system.text.json\7.0.3\buildTransitive\netstandard2.0\System.Text.Json.targets')" />

--- a/src/obj/project.assets.json
+++ b/src/obj/project.assets.json
@@ -1,327 +1,6 @@
 {
   "version": 3,
   "targets": {
-    ".NETFramework,Version=v4.7.2": {
-      "Microsoft.Bcl.AsyncInterfaces/7.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        },
-        "compile": {
-          "lib/net462/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net462/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "related": ".xml"
-          }
-        },
-        "build": {
-          "buildTransitive/net462/_._": {}
-        }
-      },
-      "Microsoft.Win32.Primitives/4.3.0": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "System",
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net46/Microsoft.Win32.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/net46/Microsoft.Win32.Primitives.dll": {}
-        }
-      },
-      "Microsoft.Win32.Registry/5.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Security.AccessControl": "5.0.0",
-          "System.Security.Principal.Windows": "5.0.0"
-        },
-        "frameworkAssemblies": [
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net461/Microsoft.Win32.Registry.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/Microsoft.Win32.Registry.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/win/lib/net461/Microsoft.Win32.Registry.dll": {
-            "assetType": "runtime",
-            "rid": "win"
-          }
-        }
-      },
-      "PowerShellStandard.Library/5.1.1": {
-        "type": "package",
-        "compile": {
-          "lib/net452/System.Management.Automation.dll": {}
-        },
-        "runtime": {
-          "lib/net452/System.Management.Automation.dll": {}
-        }
-      },
-      "System.Buffers/4.5.1": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net45/System.Buffers.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Buffers.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "System.Diagnostics.EventLog/7.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Security.Principal.Windows": "5.0.0"
-        },
-        "compile": {
-          "lib/net462/System.Diagnostics.EventLog.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net462/System.Diagnostics.EventLog.dll": {
-            "related": ".xml"
-          }
-        },
-        "build": {
-          "buildTransitive/net462/_._": {}
-        }
-      },
-      "System.Memory/4.5.5": {
-        "type": "package",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        },
-        "frameworkAssemblies": [
-          "System",
-          "mscorlib"
-        ],
-        "compile": {
-          "lib/net461/System.Memory.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Memory.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "System.Numerics.Vectors/4.5.0": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "System.Numerics",
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net46/System.Numerics.Vectors.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net46/System.Numerics.Vectors.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "System.Runtime.CompilerServices.Unsafe/6.0.0": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "mscorlib"
-        ],
-        "compile": {
-          "lib/net461/System.Runtime.CompilerServices.Unsafe.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Runtime.CompilerServices.Unsafe.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "System.Security.AccessControl/6.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Security.Principal.Windows": "5.0.0"
-        },
-        "compile": {
-          "lib/net461/System.Security.AccessControl.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Security.AccessControl.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/win/lib/net461/System.Security.AccessControl.dll": {
-            "assetType": "runtime",
-            "rid": "win"
-          }
-        }
-      },
-      "System.Security.Principal.Windows/5.0.0": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "System",
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net461/System.Security.Principal.Windows.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Security.Principal.Windows.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/win/lib/net461/System.Security.Principal.Windows.dll": {
-            "assetType": "runtime",
-            "rid": "win"
-          }
-        }
-      },
-      "System.ServiceProcess.ServiceController/7.0.1": {
-        "type": "package",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "7.0.0"
-        },
-        "frameworkAssemblies": [
-          "System.ServiceProcess"
-        ],
-        "compile": {
-          "lib/net462/System.ServiceProcess.ServiceController.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net462/System.ServiceProcess.ServiceController.dll": {
-            "related": ".xml"
-          }
-        },
-        "build": {
-          "buildTransitive/net462/_._": {}
-        }
-      },
-      "System.Text.Encodings.Web/7.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "compile": {
-          "lib/net462/System.Text.Encodings.Web.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net462/System.Text.Encodings.Web.dll": {
-            "related": ".xml"
-          }
-        },
-        "build": {
-          "buildTransitive/net462/_._": {}
-        }
-      },
-      "System.Text.Json/7.0.3": {
-        "type": "package",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "7.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "7.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
-        },
-        "compile": {
-          "lib/net462/System.Text.Json.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net462/System.Text.Json.dll": {
-            "related": ".xml"
-          }
-        },
-        "build": {
-          "buildTransitive/net462/System.Text.Json.targets": {}
-        }
-      },
-      "System.Threading.Tasks.Extensions/4.5.4": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        },
-        "frameworkAssemblies": [
-          "mscorlib"
-        ],
-        "compile": {
-          "lib/net461/System.Threading.Tasks.Extensions.dll": {
-            "related": ".xml"
-          }
-        },
-        "runtime": {
-          "lib/net461/System.Threading.Tasks.Extensions.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "System.ValueTuple/4.5.0": {
-        "type": "package",
-        "frameworkAssemblies": [
-          "mscorlib"
-        ],
-        "compile": {
-          "ref/net47/System.ValueTuple.dll": {}
-        },
-        "runtime": {
-          "lib/net47/System.ValueTuple.dll": {
-            "related": ".xml"
-          }
-        }
-      },
-      "XmlDoc2CmdletDoc/0.3.0": {
-        "type": "package",
-        "build": {
-          "build/XmlDoc2CmdletDoc.targets": {}
-        }
-      },
-      "WuCore/1.0.0": {
-        "type": "project",
-        "compile": {
-          "bin/placeholder/WuCore.dll": {}
-        },
-        "runtime": {
-          "bin/placeholder/WuCore.dll": {}
-        }
-      }
-    },
     ".NETStandard,Version=v2.0": {
       "Microsoft.Bcl.AsyncInterfaces/7.0.0": {
         "type": "package",
@@ -1420,50 +1099,6 @@
         "version.txt"
       ]
     },
-    "System.ValueTuple/4.5.0": {
-      "sha512": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ==",
-      "type": "package",
-      "path": "system.valuetuple/4.5.0",
-      "files": [
-        ".nupkg.metadata",
-        ".signature.p7s",
-        "LICENSE.TXT",
-        "THIRD-PARTY-NOTICES.TXT",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net461/System.ValueTuple.dll",
-        "lib/net461/System.ValueTuple.xml",
-        "lib/net47/System.ValueTuple.dll",
-        "lib/net47/System.ValueTuple.xml",
-        "lib/netcoreapp2.0/_._",
-        "lib/netstandard1.0/System.ValueTuple.dll",
-        "lib/netstandard1.0/System.ValueTuple.xml",
-        "lib/netstandard2.0/_._",
-        "lib/portable-net40+sl4+win8+wp8/System.ValueTuple.dll",
-        "lib/portable-net40+sl4+win8+wp8/System.ValueTuple.xml",
-        "lib/uap10.0.16299/_._",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "lib/xamarintvos10/_._",
-        "lib/xamarinwatchos10/_._",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net461/System.ValueTuple.dll",
-        "ref/net47/System.ValueTuple.dll",
-        "ref/netcoreapp2.0/_._",
-        "ref/netstandard2.0/_._",
-        "ref/portable-net40+sl4+win8+wp8/System.ValueTuple.dll",
-        "ref/uap10.0.16299/_._",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "ref/xamarintvos10/_._",
-        "ref/xamarinwatchos10/_._",
-        "system.valuetuple.4.5.0.nupkg.sha512",
-        "system.valuetuple.nuspec",
-        "useSharedDesignerContext.txt",
-        "version.txt"
-      ]
-    },
     "XmlDoc2CmdletDoc/0.3.0": {
       "sha512": "ireYcj9rKHRua77P9KmkSIlitooN+Zq7X5cY0rPjeN1QaI0H643Tle6UxzUILrl7cb+tlzDotIIGp1BxSNIvxg==",
       "type": "package",
@@ -1490,24 +1125,12 @@
     }
   },
   "projectFileDependencyGroups": {
-    ".NETFramework,Version=v4.7.2": [
-      "Microsoft.Win32.Primitives >= 4.3.0",
-      "Microsoft.Win32.Registry >= 5.0.0",
-      "PowerShellStandard.Library >= 5.1.1",
-      "System.Security.AccessControl >= 6.0.0",
-      "System.Security.Principal.Windows >= 5.0.0",
-      "System.ServiceProcess.ServiceController >= 7.0.1",
-      "System.Text.Json >= 7.0.3",
-      "WuCore >= 1.0.0",
-      "XmlDoc2CmdletDoc >= 0.3.0"
-    ],
     ".NETStandard,Version=v2.0": [
       "Microsoft.Win32.Primitives >= 4.3.0",
       "Microsoft.Win32.Registry >= 5.0.0",
       "NETStandard.Library >= 2.0.3",
       "PowerShellStandard.Library >= 5.1.1",
       "System.Security.AccessControl >= 6.0.0",
-      "System.Security.Principal.Windows >= 5.0.0",
       "System.ServiceProcess.ServiceController >= 7.0.1",
       "System.Text.Json >= 7.0.3",
       "WuCore >= 1.0.0",
@@ -1537,7 +1160,6 @@
         "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
       ],
       "originalTargetFrameworks": [
-        "net472",
         "netstandard2.0"
       ],
       "sources": {
@@ -1545,14 +1167,6 @@
         "https://api.nuget.org/v3/index.json": {}
       },
       "frameworks": {
-        "net472": {
-          "targetAlias": "net472",
-          "projectReferences": {
-            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-            }
-          }
-        },
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
           "projectReferences": {
@@ -1572,46 +1186,6 @@
       }
     },
     "frameworks": {
-      "net472": {
-        "targetAlias": "net472",
-        "dependencies": {
-          "Microsoft.Win32.Primitives": {
-            "target": "Package",
-            "version": "[4.3.0, )"
-          },
-          "Microsoft.Win32.Registry": {
-            "target": "Package",
-            "version": "[5.0.0, )"
-          },
-          "PowerShellStandard.Library": {
-            "target": "Package",
-            "version": "[5.1.1, )"
-          },
-          "System.Security.AccessControl": {
-            "target": "Package",
-            "version": "[6.0.0, )"
-          },
-          "System.Security.Principal.Windows": {
-            "target": "Package",
-            "version": "[5.0.0, )"
-          },
-          "System.ServiceProcess.ServiceController": {
-            "target": "Package",
-            "version": "[7.0.1, )"
-          },
-          "System.Text.Json": {
-            "target": "Package",
-            "version": "[7.0.3, )"
-          },
-          "XmlDoc2CmdletDoc": {
-            "include": "Runtime, Build, Native, ContentFiles, Analyzers, BuildTransitive",
-            "suppressParent": "All",
-            "target": "Package",
-            "version": "[0.3.0, )"
-          }
-        },
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.100-preview.7.23376.3\\RuntimeIdentifierGraph.json"
-      },
       "netstandard2.0": {
         "targetAlias": "netstandard2.0",
         "dependencies": {
@@ -1636,10 +1210,6 @@
           "System.Security.AccessControl": {
             "target": "Package",
             "version": "[6.0.0, )"
-          },
-          "System.Security.Principal.Windows": {
-            "target": "Package",
-            "version": "[5.0.0, )"
           },
           "System.ServiceProcess.ServiceController": {
             "target": "Package",

--- a/src/obj/project.assets.json
+++ b/src/obj/project.assets.json
@@ -304,15 +304,6 @@
         "build": {
           "build/XmlDoc2CmdletDoc.targets": {}
         }
-      },
-      "WuCore/1.0.0": {
-        "type": "project",
-        "compile": {
-          "bin/placeholder/WuCore.dll": {}
-        },
-        "runtime": {
-          "bin/placeholder/WuCore.dll": {}
-        }
       }
     }
   },
@@ -1117,11 +1108,6 @@
         "xmldoc2cmdletdoc.0.3.0.nupkg.sha512",
         "xmldoc2cmdletdoc.nuspec"
       ]
-    },
-    "WuCore/1.0.0": {
-      "type": "project",
-      "path": "ClrCore/WuCore.vcxproj",
-      "msbuildProject": "ClrCore/WuCore.vcxproj"
     }
   },
   "projectFileDependencyGroups": {
@@ -1133,7 +1119,6 @@
       "System.Security.AccessControl >= 6.0.0",
       "System.ServiceProcess.ServiceController >= 7.0.1",
       "System.Text.Json >= 7.0.3",
-      "WuCore >= 1.0.0",
       "XmlDoc2CmdletDoc >= 0.3.0"
     ]
   },
@@ -1142,13 +1127,13 @@
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
-    "version": "1.8.2",
+    "version": "1.8.3",
     "restore": {
-      "projectUniqueName": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectUniqueName": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "projectName": "WindowsUtils",
-      "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+      "projectPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
       "packagesPath": "C:\\Users\\francisco.nabas\\.nuget\\packages\\",
-      "outputPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
+      "outputPath": "c:\\LocalRepositories\\.WindowsUtils\\src\\obj\\",
       "projectStyle": "PackageReference",
       "crossTargeting": true,
       "fallbackFolders": [
@@ -1169,11 +1154,7 @@
       "frameworks": {
         "netstandard2.0": {
           "targetAlias": "netstandard2.0",
-          "projectReferences": {
-            "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj": {
-              "projectPath": "C:\\LocalRepositories\\.WindowsUtils\\src\\ClrCore\\WuCore.vcxproj"
-            }
-          }
+          "projectReferences": {}
         }
       },
       "warningProperties": {

--- a/src/obj/project.nuget.cache
+++ b/src/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "t5w3k2vfyTE1DQhCtEqndwbIQTT8gZNTO0y+WFvucXlgxrjdfJpnhQHFljZV3PYpbjQqs2vVlpoDyyIr7z2RYQ==",
+  "dgSpecHash": "W+Ra3JtxTAatvSSqkcYsbD2WAsBRdqp9h1YDSMpXsq/CvRG7h72t9SntVWI833ktJuZntWE/fhKfO5fnEyoGNA==",
   "success": true,
   "projectFilePath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
   "expectedPackageFiles": [
@@ -23,7 +23,6 @@
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\system.text.encodings.web\\7.0.0\\system.text.encodings.web.7.0.0.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\system.text.json\\7.0.3\\system.text.json.7.0.3.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\system.threading.tasks.extensions\\4.5.4\\system.threading.tasks.extensions.4.5.4.nupkg.sha512",
-    "C:\\Users\\francisco.nabas\\.nuget\\packages\\system.valuetuple\\4.5.0\\system.valuetuple.4.5.0.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\xmldoc2cmdletdoc\\0.3.0\\xmldoc2cmdletdoc.0.3.0.nupkg.sha512"
   ],
   "logs": []

--- a/src/obj/project.nuget.cache
+++ b/src/obj/project.nuget.cache
@@ -1,8 +1,8 @@
 {
   "version": 2,
-  "dgSpecHash": "W+Ra3JtxTAatvSSqkcYsbD2WAsBRdqp9h1YDSMpXsq/CvRG7h72t9SntVWI833ktJuZntWE/fhKfO5fnEyoGNA==",
+  "dgSpecHash": "vRXYTMLl11NbFximsP9ggkBmt/P7o1nomJoLL1dGr507CpJ8Oi5+M+uq/oWPHFSc0rR2fIu3cxji4Bkes2Z0Bw==",
   "success": true,
-  "projectFilePath": "C:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
+  "projectFilePath": "c:\\LocalRepositories\\.WindowsUtils\\src\\WindowsUtils.csproj",
   "expectedPackageFiles": [
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.bcl.asyncinterfaces\\7.0.0\\microsoft.bcl.asyncinterfaces.7.0.0.nupkg.sha512",
     "C:\\Users\\francisco.nabas\\.nuget\\packages\\microsoft.netcore.platforms\\1.1.0\\microsoft.netcore.platforms.1.1.0.nupkg.sha512",


### PR DESCRIPTION
Get-ObjectHandle dependencies in WindowsIdentity and Win32.Registry was keeping the cmdlet from running on Windows PowerShell due some .NET Framework shenanigans.
Moved all to C++.